### PR TITLE
Making the auth/cred gems work better in combination

### DIFF
--- a/aker_authentication_gem.gemspec
+++ b/aker_authentication_gem.gemspec
@@ -35,6 +35,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "request_store"
   spec.add_dependency "jwt"
   spec.add_dependency "activemodel"
+  spec.add_dependency "bootstrap-sass"
+  spec.add_dependency "bootstrap_form"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,11 +4,12 @@ module Users
     
     skip_authorization_check if respond_to?(:skip_authorization_check)
 
-  protected
-
-    def store_session_data
-      session["user"] = current_user
+    def devise_user
+      warden.authenticate(scope: :user)
     end
 
+    def store_session_data
+      session["user"] = devise_user
+    end
   end
 end

--- a/lib/auth_controller.rb
+++ b/lib/auth_controller.rb
@@ -1,7 +1,7 @@
 module AkerAuthenticationGem::AuthController
+
   def self.included(base)
     base.instance_eval do |klass|
-
       before_action do |controller|
         request.parameters["user"]["email"] += '@sanger.ac.uk' unless request.parameters["user"].nil? || request.parameters["user"]["email"].include?('@')
         authenticate_user! unless self.class.skip_authenticate_user?(self.action_name.to_sym)
@@ -16,27 +16,33 @@ module AkerAuthenticationGem::AuthController
         return false
       end
 
-
       def self.skip_authenticate_user(options=nil)
         @skip_authenticate_user = true
         @options_authenticate_user = options
       end
 
-      def context
-        {current_user: current_user}
-      end
-
-      def current_user
-        u = session["user"]
-        if u.is_a? Hash
-          u = User.new(u)
-        end
-        u
-      end
-
       rescue_from DeviseLdapAuthenticatable::LdapException do |exception|
-          render :text => exception, :status => 500
-      end      
+        render :text => exception, :status => 500
+      end
+
     end
+  end
+
+  def current_user
+    if respond_to? :x_auth_user
+      auth_user || x_auth_user
+    else
+      auth_user
+    end
+  end
+
+  def context
+    {current_user: current_user}
+  end
+
+  def auth_user
+    u = session["user"]
+    u = User.new(u) if u.is_a? Hash
+    u
   end
 end


### PR DESCRIPTION
Make sure the devise user information is stored in the session,
not the current_user method as overridden by some other module.
Moved some method definitions from the weird included blocks
to simply inside the AuthController module's main body.
Define auth_user to be the user object as created from
the session data. Have current_user return auth_user,
or fall back on x_auth_user (from credentials) if defined.